### PR TITLE
Updated zIndex for 'md_video'

### DIFF
--- a/theme.xml
+++ b/theme.xml
@@ -170,7 +170,7 @@ license:		creative commons CC-BY-NC-SA
 			<delay>1</delay>
 			<showSnapshotNoVideo>true</showSnapshotNoVideo>
 			<showSnapshotDelay>true</showSnapshotDelay>
-			<zIndex>70</zIndex>
+			<zIndex>69</zIndex>
 		</video>
 	
 	</view>


### PR DESCRIPTION
I updated the zIndex for the "md_video" element in theme.xml to deal with the bottom gradient bar, behind the "Developer, Players, Released, Rating" text, disappearing when videos are playing, as mentioned here:

https://retropie.org.uk/forum/topic/22439/theme-angular-theme/47

Thanks again for a great theme!